### PR TITLE
Provide perfwatcher version number

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+Git master branch

--- a/html/mainMenu.html
+++ b/html/mainMenu.html
@@ -56,11 +56,7 @@
 	</li>
 	<li><a>About</a>
 		<ul>
-			<li><a href="http://www.perfwatcher.org/" target="_new"><img src="img/perfwatcher_label.png" /></a></li>
-			<li><a href="http://collectd.org/" target="_new"><img src="img/collectd.png" /></a></li>
-			<li><a href="http://www.php.net/" target="_new"><img src="img/php.png" /></a></li>
-			<li><a href="http://jquery.com/" target="_new"><img src="img/jquery.png" /></a></li>
-			<li><a href="http://www.risacher.com/la-rache/index.php?z=2" target="_new"><img src="img/la-rache.png" /></a></li>
+			<li id="menu_about_box"><a>About...</a></li>
 		</ul>
 	</li>
 	<li><div class="ui-widget"><a>Search <input type="text" id="searchtext" /></a></div></li>

--- a/html/version.html
+++ b/html/version.html
@@ -1,0 +1,14 @@
+<p><a href="http://www.perfwatcher.org/" target="_new"><img src="img/perfwatcher_label.png" /></a></p>
+
+<p>Version : @VERSION@<!-- Version is set in top VERSION file --></p>
+<p>Author : Cyril Feraudet</p>
+<p>Licence : GPL version 2.0</p>
+
+<p>Thanks to : </p>
+<p>
+<a href="http://collectd.org/" target="_new"><img src="img/collectd.png" /></a><br />
+<a href="http://www.php.net/" target="_new"><img src="img/php.png" /></a><br />
+<a href="http://jquery.com/" target="_new"><img src="img/jquery.png" /></a><br />
+<a href="http://www.risacher.com/la-rache/index.php?z=2" target="_new"><img src="img/la-rache.png" /></a>
+</p>
+

--- a/js/perfwatcher.functions.js
+++ b/js/perfwatcher.functions.js
@@ -136,6 +136,7 @@ function hide_menu_for(node_type) {
 	$('li[id="menu_refresh_tree"]').show();
 	$('li[id="menu_refresh_status"]').show();
 	$('li[id="menu_refresh_node"]').show();
+	$('li[id="menu_about_box"]').show();
 	switch (node_type) {
 		case 'default':
 		break;
@@ -307,6 +308,19 @@ function confirmfor(optionsarg, func) {
     timeout: false
   });
   return false;
+}
+
+function perfwatcher_about_box() {
+	  $('#modalwindow').jqxWindow({ height: 287, width: 262, title: 'About Perfwatcher', isModal: true, theme: theme }).show();
+	  $('#modalwindowcontent').html('<p>About Perfwatcheur</p>');
+		$.ajax({
+			async : false, type: 'POST', url: "action.php?tpl=version",
+			complete : function (r) {
+				if(r.status) {
+					$('#modalwindowcontent').html(r.responseText);
+				}
+			}
+		});
 }
 
 function isRightClick(event) {

--- a/js/perfwatcher.js
+++ b/js/perfwatcher.js
@@ -150,6 +150,9 @@ $(document).ready(function() {
 			case 'menu_refresh_status':
 				refresh_status();
 			break;
+			case 'menu_about_box':
+				perfwatcher_about_box();
+			break;
 			default:
 				console.log('Undefined stuff : '+ $(this).attr("id"));
 			break;

--- a/php/version.php
+++ b/php/version.php
@@ -1,0 +1,32 @@
+<?php # vim: set filetype=php fdm=marker sw=4 ts=4 tw=78 et : 
+/**
+ *
+ * PHP version 5
+ *
+ * LICENSE: This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Monitoring
+ * @author    Yves Mettier <ymettier@free.fr>
+ * @copyright 2013 Yves Mettier
+ * @license   http://www.gnu.org/copyleft/lesser.html  LGPL License 2.1
+ * @link      http://www.perfwatcher.org/
+ */ 
+
+$html = file_get_contents("html/version.html");
+$version = file_get_contents("VERSION");
+if(!$version) {
+    $version = "(not found)";
+}
+
+print preg_replace("/@VERSION@/", $version, $html);
+
+?>


### PR DESCRIPTION
Hello,

Could perfwatcher provide its version number ?
For example in "About" menu.

Note : maybe you could add an "about perfwatcher" alert box with more info on perfwatcher, including the url perfwatcher.org, the author name, and the version number ?

Regards,
Yves
